### PR TITLE
Replace "use vars" with "our"

### DIFF
--- a/lib/Crypt/OpenPGP.pm
+++ b/lib/Crypt/OpenPGP.pm
@@ -18,7 +18,7 @@ use base qw( Crypt::OpenPGP::ErrorHandler );
 use File::HomeDir;
 use File::Spec;
 
-use vars qw( %COMPAT );
+our %COMPAT;
 
 ## pgp2 and pgp5 do not trim trailing whitespace from "canonical text"
 ## signatures, only from cleartext signatures.

--- a/lib/Crypt/OpenPGP/Cipher.pm
+++ b/lib/Crypt/OpenPGP/Cipher.pm
@@ -5,8 +5,7 @@ use Crypt::OpenPGP::CFB;
 use Crypt::OpenPGP::ErrorHandler;
 use base qw( Crypt::OpenPGP::ErrorHandler );
 
-use vars qw( %ALG %ALG_BY_NAME );
-%ALG = (
+our %ALG = (
     1 => 'IDEA',
     2 => 'DES3',
     3 => 'CAST5',
@@ -16,7 +15,7 @@ use vars qw( %ALG %ALG_BY_NAME );
     9 => 'Rijndael256',
     10 => 'Twofish',
 );
-%ALG_BY_NAME = map { $ALG{$_} => $_ } keys %ALG;
+our %ALG_BY_NAME = map { $ALG{$_} => $_ } keys %ALG;
 
 sub new {
     my $class = shift;

--- a/lib/Crypt/OpenPGP/Compressed.pm
+++ b/lib/Crypt/OpenPGP/Compressed.pm
@@ -7,9 +7,8 @@ use Crypt::OpenPGP::Constants qw( DEFAULT_COMPRESS );
 use Crypt::OpenPGP::ErrorHandler;
 use base qw( Crypt::OpenPGP::ErrorHandler );
 
-use vars qw( %ALG %ALG_BY_NAME );
-%ALG = ( 1 => 'ZIP', 2 => 'Zlib' );
-%ALG_BY_NAME = map { $ALG{$_} => $_ } keys %ALG;
+our %ALG = ( 1 => 'ZIP', 2 => 'Zlib' );
+our %ALG_BY_NAME = map { $ALG{$_} => $_ } keys %ALG;
 
 sub alg {
     return $_[0]->{__alg} if ref($_[0]);

--- a/lib/Crypt/OpenPGP/Constants.pm
+++ b/lib/Crypt/OpenPGP/Constants.pm
@@ -1,9 +1,7 @@
 package Crypt::OpenPGP::Constants;
 use strict;
 
-use vars qw( %CONSTANTS );
-
-%CONSTANTS = (
+our %CONSTANTS = (
     'PGP_PKT_PUBKEY_ENC' => 1,
     'PGP_PKT_SIGNATURE'  => 2,
     'PGP_PKT_SYMKEY_ENC' => 3,
@@ -27,7 +25,7 @@ use vars qw( %CONSTANTS );
     'DEFAULT_COMPRESS' => 1,
 );
 
-use vars qw( %TAGS );
+our %TAGS;
 my %RULES = (
     '^PGP_PKT' => 'packet',
 );

--- a/lib/Crypt/OpenPGP/Digest.pm
+++ b/lib/Crypt/OpenPGP/Digest.pm
@@ -4,8 +4,7 @@ use strict;
 use Crypt::OpenPGP::ErrorHandler;
 use base qw( Crypt::OpenPGP::ErrorHandler );
 
-use vars qw( %ALG %ALG_BY_NAME );
-%ALG = (
+our %ALG = (
     1 => 'MD5',
     2 => 'SHA1',
     3 => 'RIPEMD160',
@@ -14,7 +13,7 @@ use vars qw( %ALG %ALG_BY_NAME );
     10 => 'SHA512',
     11 => 'SHA224',
 );
-%ALG_BY_NAME = map { $ALG{$_} => $_ } keys %ALG;
+our %ALG_BY_NAME = map { $ALG{$_} => $_ } keys %ALG;
 
 sub new {
     my $class = shift;

--- a/lib/Crypt/OpenPGP/ErrorHandler.pm
+++ b/lib/Crypt/OpenPGP/ErrorHandler.pm
@@ -1,7 +1,7 @@
 package Crypt::OpenPGP::ErrorHandler;
 use strict;
 
-use vars qw( $ERROR );
+our $ERROR;
 
 sub new    { bless {}, shift }
 sub error  {

--- a/lib/Crypt/OpenPGP/Key.pm
+++ b/lib/Crypt/OpenPGP/Key.pm
@@ -5,13 +5,12 @@ use Carp qw( confess );
 use Crypt::OpenPGP::ErrorHandler;
 use base qw( Crypt::OpenPGP::ErrorHandler );
 
-use vars qw( %ALG %ALG_BY_NAME );
-%ALG = (
+our %ALG = (
     1 => 'RSA',
     16 => 'ElGamal',
     17 => 'DSA',
 );
-%ALG_BY_NAME = map { $ALG{$_} => $_ } keys %ALG;
+our %ALG_BY_NAME = map { $ALG{$_} => $_ } keys %ALG;
 
 sub new {
     my $class = shift;
@@ -62,7 +61,7 @@ sub can_sign { 0 }
 
 sub DESTROY { }
 
-use vars qw( $AUTOLOAD );
+our $AUTOLOAD;
 sub AUTOLOAD {
     my $key = shift;
     (my $meth = $AUTOLOAD) =~ s/.*:://;

--- a/lib/Crypt/OpenPGP/PacketFactory.pm
+++ b/lib/Crypt/OpenPGP/PacketFactory.pm
@@ -5,8 +5,7 @@ use Crypt::OpenPGP::Constants qw( :packet );
 use Crypt::OpenPGP::ErrorHandler;
 use base qw( Crypt::OpenPGP::ErrorHandler );
 
-use vars qw( %PACKET_TYPES %PACKET_TYPES_BY_CLASS );
-%PACKET_TYPES = (
+our %PACKET_TYPES = (
     PGP_PKT_PUBKEY_ENC()    => { class => 'Crypt::OpenPGP::SessionKey' },
     PGP_PKT_SIGNATURE()     => { class => 'Crypt::OpenPGP::Signature' },
     PGP_PKT_SYMKEY_ENC()    => { class => 'Crypt::OpenPGP::SKSessionKey' },
@@ -31,7 +30,7 @@ use vars qw( %PACKET_TYPES %PACKET_TYPES_BY_CLASS );
     PGP_PKT_MDC()           => { class => 'Crypt::OpenPGP::MDC' },
 );
 
-%PACKET_TYPES_BY_CLASS = map { $PACKET_TYPES{$_}{class} => $_ } keys %PACKET_TYPES;
+our %PACKET_TYPES_BY_CLASS = map { $PACKET_TYPES{$_}{class} => $_ } keys %PACKET_TYPES;
 
 sub parse {
     my $class = shift;

--- a/lib/Crypt/OpenPGP/S2k.pm
+++ b/lib/Crypt/OpenPGP/S2k.pm
@@ -7,8 +7,7 @@ use Crypt::OpenPGP::ErrorHandler;
 use Crypt::OpenPGP::Util;
 use base qw( Crypt::OpenPGP::ErrorHandler );
 
-use vars qw( %TYPES );
-%TYPES = (
+our %TYPES = (
     0 => 'Simple',
     1 => 'Salted',
     3 => 'Salt_Iter',

--- a/lib/Crypt/OpenPGP/Signature/SubPacket.pm
+++ b/lib/Crypt/OpenPGP/Signature/SubPacket.pm
@@ -4,8 +4,7 @@ use strict;
 use Crypt::OpenPGP::ErrorHandler;
 use base qw( Crypt::OpenPGP::ErrorHandler );
 
-use vars qw( %SUBPACKET_TYPES );
-%SUBPACKET_TYPES = (
+our %SUBPACKET_TYPES = (
     2  => { name => 'Signature creation time',
             r    => sub { $_[0]->get_int32 },
             w    => sub { $_[0]->put_int32($_[1]) } },

--- a/lib/Crypt/OpenPGP/Util.pm
+++ b/lib/Crypt/OpenPGP/Util.pm
@@ -4,11 +4,10 @@ use strict;
 # For some reason, FastCalc causes problems. Restrict to one of these 3 backends
 use Math::BigInt only => 'Pari,GMP,Calc';
 
-use vars qw( @EXPORT_OK @ISA );
 use Exporter;
-@EXPORT_OK = qw( bitsize bin2bigint bin2mp bigint2bin mp2bin mod_exp mod_inverse
-                 dash_escape dash_unescape canonical_text );
-@ISA = qw( Exporter );
+our @EXPORT_OK = qw( bitsize bin2bigint bin2mp bigint2bin mp2bin mod_exp mod_inverse
+                     dash_escape dash_unescape canonical_text );
+our @ISA = qw( Exporter );
 
 sub bitsize {
     my $bigint = Math::BigInt->new($_[0]);

--- a/t/01-util.t
+++ b/t/01-util.t
@@ -4,8 +4,7 @@ use Test::More tests => 63;
 use Math::BigInt;
 use Crypt::OpenPGP::Util qw( bin2bigint bigint2bin bitsize mod_exp mod_inverse );
 
-use vars qw( @TESTS );
-@TESTS = (
+my @TESTS = (
     [ 'abcdefghijklmnopqrstuvwxyz-0123456789',
       '48431489725691895261376655659836964813311343892465012587212197286379595482592365885470777',
       295 ],

--- a/t/09-config.t
+++ b/t/09-config.t
@@ -5,7 +5,7 @@ use Test::Exception;
 use Crypt::OpenPGP;
 use Crypt::OpenPGP::Config;
 
-use vars qw( $SAMPLES );
+our $SAMPLES;
 unshift @INC, 't/';
 require 'test-common.pl';
 use File::Spec;

--- a/t/10-keyring.t
+++ b/t/10-keyring.t
@@ -4,7 +4,7 @@ use Test::Exception;
 
 use_ok 'Crypt::OpenPGP::KeyRing';
 
-use vars qw( $SAMPLES );
+our $SAMPLES;
 unshift @INC, 't/';
 require 'test-common.pl';
 use File::Spec;

--- a/t/11-encrypt.t
+++ b/t/11-encrypt.t
@@ -4,7 +4,7 @@ use Test::More tests => 38;
 use Crypt::OpenPGP;
 use Crypt::OpenPGP::Message;
 
-use vars qw( $SAMPLES );
+our $SAMPLES;
 unshift @INC, 't/';
 require 'test-common.pl';
 use File::Spec;

--- a/t/12-sign.t
+++ b/t/12-sign.t
@@ -3,7 +3,7 @@ use Test::More tests => 12;
 
 use Crypt::OpenPGP;
 
-use vars qw( $SAMPLES );
+our $SAMPLES;
 unshift @INC, 't/';
 require 'test-common.pl';
 use File::Spec;

--- a/t/14-sha2-verify.t
+++ b/t/14-sha2-verify.t
@@ -3,7 +3,7 @@ use Test::More tests => 2;
 
 use Crypt::OpenPGP;
 
-use vars qw( $SAMPLES );
+our $SAMPLES;
 unshift @INC, 't/';
 require 'test-common.pl';
 use File::Spec;

--- a/t/17-issue-19482.t
+++ b/t/17-issue-19482.t
@@ -5,7 +5,7 @@ use Test::More tests => 3;
 
 use Crypt::OpenPGP;
 
-use vars qw( $SAMPLES );
+our $SAMPLES;
 unshift @INC, 't/';
 require 'test-common.pl';
 use File::Spec;

--- a/t/18-issue-20931.t
+++ b/t/18-issue-20931.t
@@ -5,7 +5,7 @@ use Test::More tests => 2;
 
 use Crypt::OpenPGP;
 
-use vars qw( $SAMPLES );
+our $SAMPLES;
 unshift @INC, 't/';
 require 'test-common.pl';
 use File::Spec;

--- a/t/19-issue-79798.t
+++ b/t/19-issue-79798.t
@@ -5,7 +5,7 @@ use Test::More tests => 2;
 
 use Crypt::OpenPGP;
 
-use vars qw( $SAMPLES );
+our $SAMPLES;
 unshift @INC, 't/';
 require 'test-common.pl';
 use File::Spec;

--- a/t/test-common.pl
+++ b/t/test-common.pl
@@ -1,5 +1,3 @@
-use vars qw( $BASE $SAMPLES );
-
 use Cwd;
 use File::Spec;
 my $pwd = cwd();
@@ -9,7 +7,7 @@ if (-f 'test-common.pl') {
 }
 elsif (-f 't/test-common.pl') {
 }
-$BASE = File::Spec->catdir(@pieces);
-$SAMPLES = File::Spec->catdir($BASE, 't', 'samples');
+our $BASE = File::Spec->catdir(@pieces);
+our $SAMPLES = File::Spec->catdir($BASE, 't', 'samples');
 
 1;


### PR DESCRIPTION
Use of this pragma is discouraged in favour of "our" under 5.06+.

This dist already uses "our" for "$VERSION".

As a side note, very glad to see this dist getting maintained again, at $WORK we have a lot of patches that would be nice to upstream :-)