### PR TITLE
Replace "use base" with "use parent"

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -38,7 +38,8 @@ my %WriteMakefileArgs = (
     "LWP::UserAgent" => 0,
     "MIME::Base64" => 0,
     "Math::BigInt" => 0,
-    "URI::Escape" => 0
+    "URI::Escape" => 0,
+    "parent" => 0
   },
   "TEST_REQUIRES" => {
     "Test::Exception" => 0,
@@ -72,7 +73,8 @@ my %FallbackPrereqs = (
   "Math::BigInt" => 0,
   "Test::Exception" => 0,
   "Test::More" => 0,
-  "URI::Escape" => 0
+  "URI::Escape" => 0,
+  "parent" => 0
 );
 
 

--- a/cpanfile
+++ b/cpanfile
@@ -20,6 +20,7 @@ requires "LWP::UserAgent" => "0";
 requires "MIME::Base64" => "0";
 requires "Math::BigInt" => "0";
 requires "URI::Escape" => "0";
+requires "parent" => "0";
 requires "perl" => "v5.8.1";
 
 on 'test' => sub {

--- a/dist.ini
+++ b/dist.ini
@@ -33,6 +33,7 @@ LWP::UserAgent = 0
 MIME::Base64   = 0
 Math::BigInt   = 0
 URI::Escape    = 0
+parent         = 0
 
 ; RT#123452 Require at least one Random Source
 Bytes::Random::Secure  = 0

--- a/lib/Crypt/OpenPGP.pm
+++ b/lib/Crypt/OpenPGP.pm
@@ -12,8 +12,7 @@ use Crypt::OpenPGP::PacketFactory;
 use Crypt::OpenPGP::Config;
 use Crypt::OpenPGP::Util;
 
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 use File::HomeDir;
 use File::Spec;

--- a/lib/Crypt/OpenPGP/Armour.pm
+++ b/lib/Crypt/OpenPGP/Armour.pm
@@ -6,8 +6,7 @@ use warnings;
 
 use Crypt::OpenPGP;
 use MIME::Base64;
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 sub armour {
     my $class = shift;

--- a/lib/Crypt/OpenPGP/Buffer.pm
+++ b/lib/Crypt/OpenPGP/Buffer.pm
@@ -5,7 +5,7 @@ use warnings;
 
 # VERSION
 
-use base qw( Data::Buffer );
+use parent qw( Data::Buffer );
 
 use Crypt::OpenPGP::Util qw( bin2mp mp2bin bitsize );
 

--- a/lib/Crypt/OpenPGP/Certificate.pm
+++ b/lib/Crypt/OpenPGP/Certificate.pm
@@ -15,8 +15,7 @@ use Crypt::OpenPGP::Constants qw( DEFAULT_CIPHER
                                   PGP_PKT_SECRET_KEY
                                   PGP_PKT_SECRET_SUBKEY );
 use Crypt::OpenPGP::Cipher;
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 {
     our %KEY_ALG = (

--- a/lib/Crypt/OpenPGP/Cipher.pm
+++ b/lib/Crypt/OpenPGP/Cipher.pm
@@ -5,8 +5,7 @@ use warnings;
 # VERSION
 
 use Crypt::OpenPGP::CFB;
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 our %ALG = (
     1 => 'IDEA',
@@ -79,7 +78,7 @@ package Crypt::OpenPGP::Cipher::IDEA;
 use strict;
 use warnings;
 
-use base qw( Crypt::OpenPGP::Cipher );
+use parent qw( Crypt::OpenPGP::Cipher );
 
 sub init {
     my $ciph = shift;
@@ -99,7 +98,7 @@ package Crypt::OpenPGP::Cipher::Blowfish;
 use strict;
 use warnings;
 
-use base qw( Crypt::OpenPGP::Cipher );
+use parent qw( Crypt::OpenPGP::Cipher );
 
 sub crypt_class { 'Crypt::Blowfish' }
 sub keysize { 16 }
@@ -109,7 +108,7 @@ package Crypt::OpenPGP::Cipher::DES3;
 use strict;
 use warnings;
 
-use base qw( Crypt::OpenPGP::Cipher );
+use parent qw( Crypt::OpenPGP::Cipher );
 
 sub crypt_class { 'Crypt::DES_EDE3' }
 sub keysize { 24 }
@@ -119,7 +118,7 @@ package Crypt::OpenPGP::Cipher::CAST5;
 use strict;
 use warnings;
 
-use base qw( Crypt::OpenPGP::Cipher );
+use parent qw( Crypt::OpenPGP::Cipher );
 
 sub crypt_class { ['Crypt::CAST5_PP', 'Crypt::CAST5'] }
 sub keysize { 16 }
@@ -129,7 +128,7 @@ package Crypt::OpenPGP::Cipher::Twofish;
 use strict;
 use warnings;
 
-use base qw( Crypt::OpenPGP::Cipher );
+use parent qw( Crypt::OpenPGP::Cipher );
 
 sub crypt_class { 'Crypt::Twofish' }
 sub keysize { 32 }
@@ -139,7 +138,7 @@ package Crypt::OpenPGP::Cipher::Rijndael;
 use strict;
 use warnings;
 
-use base qw( Crypt::OpenPGP::Cipher );
+use parent qw( Crypt::OpenPGP::Cipher );
 
 sub crypt_class { 'Crypt::Rijndael' }
 sub keysize { 16 }
@@ -149,7 +148,7 @@ package Crypt::OpenPGP::Cipher::Rijndael192;
 use strict;
 use warnings;
 
-use base qw( Crypt::OpenPGP::Cipher );
+use parent qw( Crypt::OpenPGP::Cipher );
 
 sub crypt_class { 'Crypt::Rijndael' }
 sub keysize { 24 }
@@ -159,7 +158,7 @@ package Crypt::OpenPGP::Cipher::Rijndael256;
 use strict;
 use warnings;
 
-use base qw( Crypt::OpenPGP::Cipher );
+use parent qw( Crypt::OpenPGP::Cipher );
 
 sub crypt_class { 'Crypt::Rijndael' }
 sub keysize { 32 }

--- a/lib/Crypt/OpenPGP/Ciphertext.pm
+++ b/lib/Crypt/OpenPGP/Ciphertext.pm
@@ -9,8 +9,7 @@ use Crypt::OpenPGP::Cipher;
 use Crypt::OpenPGP::Constants qw( DEFAULT_CIPHER
                                   PGP_PKT_ENCRYPTED
                                   PGP_PKT_ENCRYPTED_MDC );
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 use constant MDC_TRAILER => chr(0xd3) . chr(0x14);
 

--- a/lib/Crypt/OpenPGP/Compressed.pm
+++ b/lib/Crypt/OpenPGP/Compressed.pm
@@ -7,8 +7,7 @@ use warnings;
 use Compress::Zlib;
 use Crypt::OpenPGP::Buffer;
 use Crypt::OpenPGP::Constants qw( DEFAULT_COMPRESS );
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 our %ALG = ( 1 => 'ZIP', 2 => 'Zlib' );
 our %ALG_BY_NAME = map { $ALG{$_} => $_ } keys %ALG;

--- a/lib/Crypt/OpenPGP/Config.pm
+++ b/lib/Crypt/OpenPGP/Config.pm
@@ -4,8 +4,7 @@ use warnings;
 
 # VERSION
 
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 sub new {
     my $class = shift;

--- a/lib/Crypt/OpenPGP/Digest.pm
+++ b/lib/Crypt/OpenPGP/Digest.pm
@@ -4,8 +4,7 @@ use warnings;
 
 # VERSION
 
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 our %ALG = (
     1 => 'MD5',
@@ -57,7 +56,7 @@ package Crypt::OpenPGP::Digest::MD5;
 use strict;
 use warnings;
 
-use base qw( Crypt::OpenPGP::Digest );
+use parent qw( Crypt::OpenPGP::Digest );
 
 sub init {
     my $dig = shift;
@@ -70,7 +69,7 @@ package Crypt::OpenPGP::Digest::SHA1;
 use strict;
 use warnings;
 
-use base qw( Crypt::OpenPGP::Digest );
+use parent qw( Crypt::OpenPGP::Digest );
 
 sub init {
     my $dig = shift;
@@ -83,7 +82,7 @@ package Crypt::OpenPGP::Digest::RIPEMD160;
 use strict;
 use warnings;
 
-use base qw( Crypt::OpenPGP::Digest );
+use parent qw( Crypt::OpenPGP::Digest );
 
 sub init {
     my $dig = shift;
@@ -96,7 +95,7 @@ package Crypt::OpenPGP::Digest::SHA224;
 use strict;
 use warnings;
 
-use base qw( Crypt::OpenPGP::Digest );
+use parent qw( Crypt::OpenPGP::Digest );
 
 sub init {
     my $dig = shift;
@@ -109,7 +108,7 @@ package Crypt::OpenPGP::Digest::SHA256;
 use strict;
 use warnings;
 
-use base qw( Crypt::OpenPGP::Digest );
+use parent qw( Crypt::OpenPGP::Digest );
 
 sub init {
     my $dig = shift;
@@ -122,7 +121,7 @@ package Crypt::OpenPGP::Digest::SHA384;
 use strict;
 use warnings;
 
-use base qw( Crypt::OpenPGP::Digest );
+use parent qw( Crypt::OpenPGP::Digest );
 
 sub init {
     my $dig = shift;
@@ -135,7 +134,7 @@ package Crypt::OpenPGP::Digest::SHA512;
 use strict;
 use warnings;
 
-use base qw( Crypt::OpenPGP::Digest );
+use parent qw( Crypt::OpenPGP::Digest );
 
 sub init {
     my $dig = shift;

--- a/lib/Crypt/OpenPGP/ErrorHandler.pm
+++ b/lib/Crypt/OpenPGP/ErrorHandler.pm
@@ -29,8 +29,7 @@ Crypt::OpenPGP::ErrorHandler - Crypt::OpenPGP error handling
 =head1 SYNOPSIS
 
     package Foo;
-    use Crypt::OpenPGP::ErrorHandler;
-    use base qw( Crypt::OpenPGP::ErrorHandler );
+    use parent qw( Crypt::OpenPGP::ErrorHandler );
 
     sub class_method {
         my $class = shift;

--- a/lib/Crypt/OpenPGP/Key.pm
+++ b/lib/Crypt/OpenPGP/Key.pm
@@ -5,8 +5,7 @@ use warnings;
 # VERSION
 
 use Carp qw( confess );
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 our %ALG = (
     1 => 'RSA',

--- a/lib/Crypt/OpenPGP/Key/Public.pm
+++ b/lib/Crypt/OpenPGP/Key/Public.pm
@@ -4,9 +4,7 @@ use warnings;
 
 # VERSION
 
-use Crypt::OpenPGP::Key;
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::Key Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::Key Crypt::OpenPGP::ErrorHandler );
 
 sub all_props { $_[0]->public_props }
 sub is_secret { 0 }

--- a/lib/Crypt/OpenPGP/Key/Public/DSA.pm
+++ b/lib/Crypt/OpenPGP/Key/Public/DSA.pm
@@ -4,9 +4,7 @@ use strict;
 # VERSION
 
 use Crypt::DSA::Key;
-use Crypt::OpenPGP::Key::Public;
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::Key::Public Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::Key::Public Crypt::OpenPGP::ErrorHandler );
 
 sub can_sign { 1 }
 sub abbrev { 'D' }

--- a/lib/Crypt/OpenPGP/Key/Public/ElGamal.pm
+++ b/lib/Crypt/OpenPGP/Key/Public/ElGamal.pm
@@ -4,9 +4,7 @@ use strict;
 # VERSION
 
 use Crypt::OpenPGP::Util qw( bitsize);
-use Crypt::OpenPGP::Key::Public;
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::Key::Public Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::Key::Public Crypt::OpenPGP::ErrorHandler );
 
 sub can_encrypt { 1 }
 sub abbrev { 'g' }

--- a/lib/Crypt/OpenPGP/Key/Public/RSA.pm
+++ b/lib/Crypt/OpenPGP/Key/Public/RSA.pm
@@ -6,9 +6,7 @@ use strict;
 use Crypt::RSA::Key::Public;
 use Crypt::OpenPGP::Digest;
 use Crypt::OpenPGP::Util qw( bitsize bin2mp mp2bin );
-use Crypt::OpenPGP::Key::Public;
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::Key::Public Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::Key::Public Crypt::OpenPGP::ErrorHandler );
 
 sub can_encrypt { 1 }
 sub can_sign { 1 }

--- a/lib/Crypt/OpenPGP/Key/Secret.pm
+++ b/lib/Crypt/OpenPGP/Key/Secret.pm
@@ -4,9 +4,7 @@ use warnings;
 
 # VERSION
 
-use Crypt::OpenPGP::Key;
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::Key Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::Key Crypt::OpenPGP::ErrorHandler );
 
 sub is_secret { 1 }
 sub all_props { ($_[0]->public_props, $_[0]->secret_props) }

--- a/lib/Crypt/OpenPGP/Key/Secret/DSA.pm
+++ b/lib/Crypt/OpenPGP/Key/Secret/DSA.pm
@@ -6,9 +6,7 @@ use warnings;
 
 use Crypt::DSA::Key;
 use Crypt::OpenPGP::Key::Public::DSA;
-use Crypt::OpenPGP::Key::Secret;
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::Key::Secret Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::Key::Secret Crypt::OpenPGP::ErrorHandler );
 
 sub secret_props { qw( x ) }
 *sig_props = \&Crypt::OpenPGP::Key::Public::DSA::sig_props;

--- a/lib/Crypt/OpenPGP/Key/Secret/ElGamal.pm
+++ b/lib/Crypt/OpenPGP/Key/Secret/ElGamal.pm
@@ -5,9 +5,7 @@ use warnings;
 # VERSION
 
 use Crypt::OpenPGP::Key::Public::ElGamal;
-use Crypt::OpenPGP::Key::Secret;
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::Key::Secret Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::Key::Secret Crypt::OpenPGP::ErrorHandler );
 
 sub secret_props { qw( x ) }
 *public_props = \&Crypt::OpenPGP::Key::Public::ElGamal::public_props;

--- a/lib/Crypt/OpenPGP/Key/Secret/RSA.pm
+++ b/lib/Crypt/OpenPGP/Key/Secret/RSA.pm
@@ -6,10 +6,8 @@ use warnings;
 
 use Crypt::RSA::Key::Private;
 use Crypt::OpenPGP::Key::Public::RSA;
-use Crypt::OpenPGP::Key::Secret;
 use Crypt::OpenPGP::Util qw( bin2mp );
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::Key::Secret Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::Key::Secret Crypt::OpenPGP::ErrorHandler );
 
 sub secret_props { qw( d p q u ) }
 *sig_props = \&Crypt::OpenPGP::Key::Public::RSA::sig_props;

--- a/lib/Crypt/OpenPGP/KeyRing.pm
+++ b/lib/Crypt/OpenPGP/KeyRing.pm
@@ -12,8 +12,7 @@ use Crypt::OpenPGP::Constants qw( PGP_PKT_USER_ID
 use Crypt::OpenPGP::Buffer;
 use Crypt::OpenPGP::KeyBlock;
 use Crypt::OpenPGP::PacketFactory;
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 sub new {
     my $class = shift;

--- a/lib/Crypt/OpenPGP/KeyServer.pm
+++ b/lib/Crypt/OpenPGP/KeyServer.pm
@@ -9,8 +9,7 @@ use Crypt::OpenPGP::KeyRing;
 use LWP::UserAgent;
 use URI::Escape;
 
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 sub new {
     my $class = shift;

--- a/lib/Crypt/OpenPGP/MDC.pm
+++ b/lib/Crypt/OpenPGP/MDC.pm
@@ -5,8 +5,7 @@ use warnings;
 # VERSION
 
 use Crypt::OpenPGP::Digest;
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 sub new {
     my $mdc = bless { }, shift;

--- a/lib/Crypt/OpenPGP/Marker.pm
+++ b/lib/Crypt/OpenPGP/Marker.pm
@@ -4,8 +4,7 @@ use warnings;
 
 # VERSION
 
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 sub new { bless { }, $_[0] }
 sub parse {

--- a/lib/Crypt/OpenPGP/Message.pm
+++ b/lib/Crypt/OpenPGP/Message.pm
@@ -6,8 +6,7 @@ use warnings;
 
 use Crypt::OpenPGP::Buffer;
 use Crypt::OpenPGP::PacketFactory;
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 sub new {
     my $class = shift;

--- a/lib/Crypt/OpenPGP/PacketFactory.pm
+++ b/lib/Crypt/OpenPGP/PacketFactory.pm
@@ -5,8 +5,7 @@ use warnings;
 # VERSION
 
 use Crypt::OpenPGP::Constants qw( :packet );
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 our %PACKET_TYPES = (
     PGP_PKT_PUBKEY_ENC()    => { class => 'Crypt::OpenPGP::SessionKey' },

--- a/lib/Crypt/OpenPGP/Plaintext.pm
+++ b/lib/Crypt/OpenPGP/Plaintext.pm
@@ -5,8 +5,7 @@ use warnings;
 # VERSION
 
 use Crypt::OpenPGP::Buffer;
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 sub new {
     my $class = shift;

--- a/lib/Crypt/OpenPGP/S2k.pm
+++ b/lib/Crypt/OpenPGP/S2k.pm
@@ -6,9 +6,8 @@ use warnings;
 
 use Crypt::OpenPGP::Buffer;
 use Crypt::OpenPGP::Digest;
-use Crypt::OpenPGP::ErrorHandler;
 use Crypt::OpenPGP::Util;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 our %TYPES = (
     0 => 'Simple',
@@ -55,7 +54,7 @@ sub set_hash {
 }
 
 package Crypt::OpenPGP::S2k::Simple;
-use base qw( Crypt::OpenPGP::S2k );
+use parent qw( Crypt::OpenPGP::S2k );
 
 use Crypt::OpenPGP::Constants qw( DEFAULT_DIGEST );
 
@@ -85,7 +84,7 @@ sub save {
 }
 
 package Crypt::OpenPGP::S2k::Salted;
-use base qw( Crypt::OpenPGP::S2k );
+use parent qw( Crypt::OpenPGP::S2k );
 
 use Crypt::OpenPGP::Constants qw( DEFAULT_DIGEST );
 
@@ -118,7 +117,7 @@ sub save {
 }
 
 package Crypt::OpenPGP::S2k::Salt_Iter;
-use base qw( Crypt::OpenPGP::S2k );
+use parent qw( Crypt::OpenPGP::S2k );
 
 use Crypt::OpenPGP::Constants qw( DEFAULT_DIGEST );
 

--- a/lib/Crypt/OpenPGP/SKSessionKey.pm
+++ b/lib/Crypt/OpenPGP/SKSessionKey.pm
@@ -7,8 +7,7 @@ use warnings;
 use Crypt::OpenPGP::Constants qw( DEFAULT_CIPHER );
 use Crypt::OpenPGP::Buffer;
 use Crypt::OpenPGP::S2k;
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 sub new {
     my $class = shift;

--- a/lib/Crypt/OpenPGP/SessionKey.pm
+++ b/lib/Crypt/OpenPGP/SessionKey.pm
@@ -8,8 +8,7 @@ use Crypt::OpenPGP::Constants qw( DEFAULT_CIPHER );
 use Crypt::OpenPGP::Key::Public;
 use Crypt::OpenPGP::Util qw( mp2bin bin2mp bitsize );
 use Crypt::OpenPGP::Buffer;
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 sub key_id { $_[0]->{key_id} }
 

--- a/lib/Crypt/OpenPGP/Signature.pm
+++ b/lib/Crypt/OpenPGP/Signature.pm
@@ -8,8 +8,7 @@ use Crypt::OpenPGP::Digest;
 use Crypt::OpenPGP::Signature::SubPacket;
 use Crypt::OpenPGP::Key::Public;
 use Crypt::OpenPGP::Constants qw( DEFAULT_DIGEST );
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 sub pkt_hdrlen { 2 }
 

--- a/lib/Crypt/OpenPGP/Signature/SubPacket.pm
+++ b/lib/Crypt/OpenPGP/Signature/SubPacket.pm
@@ -4,8 +4,7 @@ use warnings;
 
 # VERSION
 
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 our %SUBPACKET_TYPES = (
     2  => { name => 'Signature creation time',

--- a/lib/Crypt/OpenPGP/Trust.pm
+++ b/lib/Crypt/OpenPGP/Trust.pm
@@ -4,8 +4,7 @@ use warnings;
 
 # VERSION
 
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 sub new { bless { }, $_[0] }
 sub flags { $_[0]->{flags} }

--- a/lib/Crypt/OpenPGP/UserAttribute.pm
+++ b/lib/Crypt/OpenPGP/UserAttribute.pm
@@ -4,8 +4,7 @@ use warnings;
 
 # VERSION
 
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 sub new {
     my $id = bless { }, shift;

--- a/lib/Crypt/OpenPGP/UserID.pm
+++ b/lib/Crypt/OpenPGP/UserID.pm
@@ -4,8 +4,7 @@ use warnings;
 
 # VERSION
 
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 sub new {
     my $id = bless { }, shift;

--- a/lib/Crypt/OpenPGP/Words.pm
+++ b/lib/Crypt/OpenPGP/Words.pm
@@ -4,8 +4,7 @@ use warnings;
 
 # VERSION
 
-use Crypt::OpenPGP::ErrorHandler;
-use base qw( Crypt::OpenPGP::ErrorHandler );
+use parent qw( Crypt::OpenPGP::ErrorHandler );
 
 ## Biometric word lists as defined in manual for
 ## PGPFreeware for Windows 6.5.1, Appendix D


### PR DESCRIPTION
As per the documentation, parent is encouraged these days:

> Unless you are using the fields pragma, consider this module discouraged in favor of the lighter-weight parent.

And we're not using the fields pragma.

Since parent is only core from 5.10+ we add parent to the list of dependencies for Perl 5.8 users.

Unlike base, parent actually fails when it can't load the base class which means we can both remove some explicit use lines but also make the codebase more robust since not all use lines were present, for example Data::Buffer.