### PR TITLE
Remove superfluous evals from requires

### DIFF
--- a/lib/Crypt/OpenPGP/Certificate.pm
+++ b/lib/Crypt/OpenPGP/Certificate.pm
@@ -48,7 +48,7 @@ sub init {
         $cert->{version} = $param{Version} || 4;
         $cert->{key} = $key;
         our %KEY_ALG;
-        eval require Crypt::DSA::GMP if $KEY_ALG{$key->alg_id} eq 'DSA';
+        require Crypt::DSA::GMP if $KEY_ALG{$key->alg_id} eq 'DSA';
         $cert->{is_secret} = $key->is_secret;
         $cert->{is_subkey} = $param{Subkey} || 0;
         $cert->{timestamp} = time;
@@ -90,7 +90,7 @@ sub uid {
 sub public_cert {
     my $cert = shift;
     our %KEY_ALG;
-    eval require Crypt::DSA::GMP if $KEY_ALG{$cert->pk_alg} eq 'DSA';
+    require Crypt::DSA::GMP if $KEY_ALG{$cert->pk_alg} eq 'DSA';
     return $cert unless $cert->is_secret;
     my $pub = (ref $cert)->new;
     for my $f (qw( version timestamp pk_alg is_subkey )) {

--- a/lib/Crypt/OpenPGP/Signature.pm
+++ b/lib/Crypt/OpenPGP/Signature.pm
@@ -156,7 +156,7 @@ sub parse {
         }
     }
     our %KEY_ALG;
-    eval require Crypt::DSA::GMP if $KEY_ALG{$sig->{pk_alg}} eq 'DSA'; 
+    require Crypt::DSA::GMP if $KEY_ALG{$sig->{pk_alg}} eq 'DSA';
     $sig->{chk} = $buf->get_bytes(2);
     ## XXX should be Crypt::OpenPGP::Signature->new($sig->{pk_alg})?
     my $key = Crypt::OpenPGP::Key::Public->new($sig->{pk_alg})


### PR DESCRIPTION
`eval require Foo` evaluates the result of requiring Foo, which is the meaningless string "1". Perhaps the code intended to use `eval BLOCK` which would catch any error in requiring the module.

However just dropping the evals, maintains the existing behaviour (throwing on missing modules) and matches what the original ticket wanted ([RT#12237](https://rt.cpan.org/Public/Bug/Display.html?id=12237)).